### PR TITLE
Use node timers instead of minetest.after()

### DIFF
--- a/api.lua
+++ b/api.lua
@@ -16,8 +16,15 @@ light_tool.light_beam = function(pos, dir, range)
 		local lightable = light_tool.check(light_tool.lightable_nodes, node.name)
 		local lightable_index = light_tool.check_index(light_tool.lightable_nodes, node.name)
 		local lit = light_tool.check(light_tool.lit_nodes, node.name)
-        if node.name == "air" or node.name == "light_tool:light" then
-	        minetest.set_node(new_pos, {name = "light_tool:light"})
+
+		if node.name == "air" then
+			-- Place temporary light nodes in air:
+			minetest.set_node(new_pos, {name = "light_tool:light"})
+			minetest.get_node_timer(new_pos):start(0.2)
+			light_positions[i] = new_pos
+		elseif node.name == "light_tool:light" then
+			-- Reset destruction timer for this light node:
+			minetest.get_node_timer(new_pos):start(0.2)
         elseif lightable or node.name == lit then
 	        
 	        local index = light_tool.check_index(light_tool.lightable_nodes, node.name)

--- a/api.lua
+++ b/api.lua
@@ -14,7 +14,6 @@ light_tool.light_beam = function(pos, dir, range)
 		
 		
 		local lightable = light_tool.check(light_tool.lightable_nodes, node.name)
-		local lightable_index = light_tool.check_index(light_tool.lightable_nodes, node.name)
 		local lit = light_tool.check(light_tool.lit_nodes, node.name)
 
 		if node.name == "air" then
@@ -22,13 +21,16 @@ light_tool.light_beam = function(pos, dir, range)
 			minetest.set_node(new_pos, {name = "light_tool:light"})
 			minetest.get_node_timer(new_pos):start(0.2)
 		elseif node.name == "light_tool:light" then
-			-- Reset destruction timer for this light node:
+			-- Extend lifetime for this light node:
 			minetest.get_node_timer(new_pos):start(0.2)
-        elseif lightable or node.name == lit then
-	        
-	        local index = light_tool.check_index(light_tool.lightable_nodes, node.name)
-	        minetest.set_node(new_pos, {name = light_tool.lightable_nodes[index].."_glowing"})
-	        
+        elseif lightable then
+			-- Place temporary glow node in lightable node:
+			local index = light_tool.check_index(light_tool.lightable_nodes, node.name)
+			minetest.set_node(new_pos, {name = light_tool.lightable_nodes[index].."_glowing"})
+			minetest.get_node_timer(new_pos):start(0.2)
+		elseif node.name == lit then
+			-- Extend lifetime for this glow node:
+			minetest.get_node_timer(new_pos):start(0.2)
         elseif node.name and minetest.registered_nodes[node.name].sunlight_propagates == false and not lightable and not lit then
 			break
 		end
@@ -49,17 +51,22 @@ light_tool.register_glow_node = function(name)
 		return
 	end
 	
+	-- The following creates a temporary light source definition, which forms the light beam of a flashlight.
+	-- When you constructed such nodes, call minetest.get_node_timer(pos):start(lifetime) to make it delete itself.
+	-- Call start() again to extend the lifetime.
 	local node = minetest.registered_nodes[name]
 	local def = table.copy(node)
 	
 	def.paramtype = "light"
 	def.light_source = 4
-	def.on_construct = function(pos)
-		minetest.after(0.1, function()
-	        minetest.set_node(pos, {name = name})
-	    end)
-    end
-    
+	def.on_timer = function(pos)
+		minetest.set_node(pos, {name = name})
+	end
+
+	minetest.register_node(":"..name.."_glowing", def)
+	table.insert(light_tool.lightable_nodes, name)
+	table.insert(light_tool.lit_nodes, name.."_glowing")
+
 	minetest.register_lbm({
 		name = ":"..name.."_glowing_removal",
 		nodenames = {name.."_glowing"},
@@ -68,9 +75,6 @@ light_tool.register_glow_node = function(name)
 			minetest.set_node(pos, {name = name})
 		end,
 	})
-	minetest.register_node(":"..name.."_glowing", def)
-	table.insert(light_tool.lightable_nodes, name)
-	table.insert(light_tool.lit_nodes, name.."_glowing")
 end
 light_tool.directional_pos = function(pos, direction, multiplier, addition)
 	if addition == nil then

--- a/api.lua
+++ b/api.lua
@@ -21,7 +21,6 @@ light_tool.light_beam = function(pos, dir, range)
 			-- Place temporary light nodes in air:
 			minetest.set_node(new_pos, {name = "light_tool:light"})
 			minetest.get_node_timer(new_pos):start(0.2)
-			light_positions[i] = new_pos
 		elseif node.name == "light_tool:light" then
 			-- Reset destruction timer for this light node:
 			minetest.get_node_timer(new_pos):start(0.2)

--- a/init.lua
+++ b/init.lua
@@ -9,6 +9,9 @@ minetest.register_tool("light_tool:light_tool", {
 })
 light_tool.add_tool("light_tool:light_tool", 20)
 
+-- This is a temporary light source which forms the light beam of a flashlight.
+-- When you constructed it, call minetest.get_node_timer(pos):start(lifetime) to make it delete itself.
+-- Call start() again to extend the lifetime.
 minetest.register_node("light_tool:light", {
 	drawtype = "airlike",
 	tiles = {"blank.png"},

--- a/init.lua
+++ b/init.lua
@@ -18,10 +18,8 @@ minetest.register_node("light_tool:light", {
 	light_source = 8,
 	pointable = false,
 	buildable_to = true, 
-	on_construct = function(pos)
-		minetest.after(0.1, function()
-			minetest.set_node(pos, {name = "air"})
-		end)
+	on_timer = function(pos)
+		minetest.set_node(pos, {name = "air"})
 	end,
 })
 


### PR DESCRIPTION
This reduces the amount of necessary map block updates.

Before this, temporary light sources were removed and readded in every step, which caused a no-op block update everytime. After this, light_beam() just restarts the node timer, so no nodes actually change when you don’t move the light beam.

This can be observed, after pressing F5 twice, in the client_received_packets graph (yellow).

Additionally, this makes the light beam work over the full active_block_range (when you don’t move), because temporary light sources are static then, so the server considers a block update appropriate.

Unfortunately, this doesn’t work with water. I think, the glow nodes are flooded in a way different to e. g. torches, where on_flood() is not executed.

---

I suggest to sqash-merge this.